### PR TITLE
Fix NBS format doc missing "Note blocks removed"

### DIFF
--- a/nbs.md
+++ b/nbs.md
@@ -140,6 +140,11 @@
 						<td>The amount of times the user have added a note block.</td>
 					</tr>
 					<tr>
+						<td>Integer</td>
+						<td>Note blocks removed</td>
+						<td>The amount of times the user have removed a note block.</td>
+					</tr>
+					<tr>
 						<td>String</td>
 						<td>MIDI/Schematic file name</td>
 						<td>If the song has been imported from a .mid or .schematic file, that file name is stored here (Only the name of the file, not the path).</td>


### PR DESCRIPTION
See source:
https://github.com/HielkeMinecraft/OpenNoteBlockStudio/blob/9b525cc3289c274e2a6f58ce5250105ed099e0a8/scripts/save_song/save_song.gml#L43-L44