### PR TITLE
Auto-updater/Download new versions automatically

### DIFF
--- a/Minecraft Note Block Studio.yyp
+++ b/Minecraft Note Block Studio.yyp
@@ -1031,6 +1031,14 @@
             }
         },
         {
+            "Key": "3c1514e1-5885-49b4-86ef-115f1fdec3ea",
+            "Value": {
+                "id": "a12fd799-06e2-4b03-94e2-28c9e406f39e",
+                "resourcePath": "scripts\\check_updates\\check_updates.yy",
+                "resourceType": "GMScript"
+            }
+        },
+        {
             "Key": "3c3845a5-e4dd-4c4f-85c2-1ec8e589979c",
             "Value": {
                 "id": "57616e0a-01d0-4351-a035-0738eec83202",
@@ -3815,6 +3823,14 @@
             }
         },
         {
+            "Key": "e74f03fa-1407-4d25-93ab-0dccb3eb91ca",
+            "Value": {
+                "id": "922ab784-ea4b-4bb9-83da-0ddc43463332",
+                "resourcePath": "scripts\\get_update\\get_update.yy",
+                "resourceType": "GMScript"
+            }
+        },
+        {
             "Key": "e7ef2956-a38a-44fc-858f-fcc654140bb3",
             "Value": {
                 "id": "6a8628f3-26bc-4420-9f2a-b6b74ce70c6b",
@@ -4163,6 +4179,8 @@
         "0ce5a906-0342-42fb-89f3-04f3609f5689",
         "3ef34f15-11b7-471c-aa91-4f191100f959",
         "0097ab11-b126-461a-8194-e3aaf09a6ddd",
+        "3c1514e1-5885-49b4-86ef-115f1fdec3ea",
+        "e74f03fa-1407-4d25-93ab-0dccb3eb91ca",
         "f51781f2-7a5a-49bf-895e-4338650ab87c",
         "5a190bcc-d435-4a9c-ab94-dc50a0f3107d",
         "5dcc6852-84c3-404a-9c42-174e7315465a",

--- a/Minecraft Note Block Studio.yyp
+++ b/Minecraft Note Block Studio.yyp
@@ -3935,6 +3935,14 @@
             }
         },
         {
+            "Key": "f136e3ca-963a-4648-ae87-60c3ee8476a9",
+            "Value": {
+                "id": "af2a944a-2b4a-4349-adf6-66e1b3b3936e",
+                "resourcePath": "scripts\\file_get_size\\file_get_size.yy",
+                "resourceType": "GMScript"
+            }
+        },
+        {
             "Key": "f156b801-b9bb-4929-af5c-2b9df4acc238",
             "Value": {
                 "id": "28a79843-5cfc-44c5-b54c-7df2f718c5c2",
@@ -4220,6 +4228,7 @@
         "af9a3525-3682-420e-b2a0-d952cc347296",
         "a0fe9bd7-a654-4de6-abd8-41b5be7e41a8",
         "7dfa1c5c-2dd7-4604-a776-ff2a1c2d26b0",
+        "f136e3ca-963a-4648-ae87-60c3ee8476a9",
         "1501c0c9-c863-4723-9ccc-f004078dc78d",
         "c032c6f1-0ef4-493c-82d0-cbc09ed91a90",
         "c54d19c6-44b4-403d-83b5-46645ef6d7d0",

--- a/Minecraft Note Block Studio.yyp
+++ b/Minecraft Note Block Studio.yyp
@@ -647,6 +647,14 @@
             }
         },
         {
+            "Key": "252af0d3-fda0-4686-99ee-e50c77599791",
+            "Value": {
+                "id": "6b3ab05d-6386-40a1-9e9d-e82a79991252",
+                "resourcePath": "scripts\\draw_downloadprogress\\draw_downloadprogress.yy",
+                "resourceType": "GMScript"
+            }
+        },
+        {
             "Key": "262425f5-3f8a-4051-87ac-9e5516650c6f",
             "Value": {
                 "id": "e1969937-9d58-4822-9a5c-ef3e0e4136ef",
@@ -4303,6 +4311,7 @@
         "28131748-b621-459e-952c-fcd16de0bd8b",
         "36bf530d-9afd-4915-8e0f-6d9162ea03b2",
         "f6cfba59-defd-47c1-b2fa-8fa627a1c1a4",
+        "252af0d3-fda0-4686-99ee-e50c77599791",
         "ffdb58ba-3567-4019-acf7-c6e674131bbb",
         "bb77e968-5a4f-4c9d-954b-7ddca77d2c0a",
         "a38ae6de-e436-4b50-af0b-964bf5f26cd9",

--- a/scripts/check_updates/check_updates.gml
+++ b/scripts/check_updates/check_updates.gml
@@ -1,0 +1,34 @@
+// check_updates()
+// Handles the update checking
+// update values:
+// -1: unable to check for update
+// 1: update found
+// 2: up to date
+
+if (async_load[? "id"] = update_http) {
+    update_http = -1
+    if (async_load[? "http_status"] = 200) {
+        var res = async_load[? "result"];
+        if (is_string(res)) {
+			res = json_decode(res)
+			if(res[?"tag_name"] != undefined){ 
+				var newVersion = string_replace(res[?"tag_name"],"v","")
+				if (string_count(".", newVersion) = 2) {
+					if (newVersion = version) {
+					  update = 2
+					} else {
+						if (question("Version " + newVersion + " is available! Do you want to download it?", "Update available!")) {
+							update_download = http_get_file("https://github.com/HielkeMinecraft/OpenNoteBlockStudio/releases/latest/download/Minecraft.Note.Block.Studio.exe", update_file)
+							update = 4
+						} else {
+							update = 1
+						}
+					}
+				}
+			}else
+			   update = -1
+        }else
+		   update = -1
+    } else
+        update = -1
+}

--- a/scripts/check_updates/check_updates.yy
+++ b/scripts/check_updates/check_updates.yy
@@ -1,0 +1,8 @@
+{
+    "id": "3c1514e1-5885-49b4-86ef-115f1fdec3ea",
+    "modelName": "GMScript",
+    "mvc": "1.0",
+    "name": "check_updates",
+    "IsCompatibility": false,
+    "IsDnD": false
+}

--- a/scripts/control_create/control_create.gml
+++ b/scripts/control_create/control_create.gml
@@ -333,6 +333,8 @@ save_version = nbs_version
 load_settings()
 change_theme()
 if (show_welcome) window = w_greeting
+
+// Updates
 if (check_update)
     update_http = http_get("https://api.github.com/repos/HielkeMinecraft/OpenNoteBlockStudio/releases/latest")
 else
@@ -344,7 +346,11 @@ if (file_exists_lib(settings_file) && vers != version) {
     window = w_update
     update = 3
 }
-log("Startup OK")
+
+// Delete old installer
+if (file_exists_lib(update_file)) {
+	files_delete_lib(update_file)
+}
 
 // Auto-recovery
 if (file_exists_lib(backup_file)) {
@@ -358,3 +364,5 @@ if (parameter_count() > 0) {
 	filename = parameter_string(1)
 	if (filename != "") load_song(filename)
 }
+
+log("Startup OK")

--- a/scripts/control_create/control_create.gml
+++ b/scripts/control_create/control_create.gml
@@ -337,6 +337,9 @@ if (check_update)
     update_http = http_get("https://api.github.com/repos/HielkeMinecraft/OpenNoteBlockStudio/releases/latest")
 else
     update_http = -1
+update_download = -1
+downloaded_size = 0
+total_size = -1
 if (file_exists_lib(settings_file) && vers != version) {
     window = w_update
     update = 3

--- a/scripts/control_draw/control_draw.gml
+++ b/scripts/control_draw/control_draw.gml
@@ -1324,26 +1324,10 @@ if (mouse_check_button_released(mb_left)) {
 if (window = w_releasemouse && !mouse_check_button(mb_left)) window = 0
 draw_windows()
 
-// Draw update progress
-if (update == 4 or update == 5) {
+// Draw update progress bar
+if (update == 4) {
 	window = -1
 	draw_loading("Update", "Downloading update...", downloaded_size, total_size)
-	if (update == 5) {
-		if (file_get_size(update_file) == total_size) {
-			update = 1
-			show_message("Download complete! Click OK to begin installing the update.")
-			// At this point, the game is paused until the user dismisses the message
-			ExecuteShell(update_file, false, true)
-			game_end()
-		} else {
-			if (question("Failed to download update. Do you want to open the Note Block Studio website and update manually?", "Failed")) {
-				open_url(link_download)
-			}
-		window = w_greeting
-		update_download = -1
-		update = 1
-		}
-	}
 }
 
 window_set_cursor(curs)

--- a/scripts/control_draw/control_draw.gml
+++ b/scripts/control_draw/control_draw.gml
@@ -1327,7 +1327,7 @@ draw_windows()
 // Draw update progress bar
 if (update == 4) {
 	window = -1
-	draw_loading("Update", "Downloading update...", downloaded_size, total_size)
+	draw_downloadprogress("Update", "Downloading update...", downloaded_size, total_size)
 }
 
 window_set_cursor(curs)

--- a/scripts/control_draw/control_draw.gml
+++ b/scripts/control_draw/control_draw.gml
@@ -1323,6 +1323,14 @@ if (mouse_check_button_released(mb_left)) {
 }
 if (window = w_releasemouse && !mouse_check_button(mb_left)) window = 0
 draw_windows()
+
+// Draw update progress
+if (update == 4) {
+	window = -1
+	// show_debug_message(string(downloaded_size) + "/" + string(total_size))
+	draw_loading("Update", "Downloading update...", downloaded_size, total_size)
+}
+
 window_set_cursor(curs)
 mouse_xprev = mouse_x
 mouse_yprev = mouse_y

--- a/scripts/control_draw/control_draw.gml
+++ b/scripts/control_draw/control_draw.gml
@@ -1325,10 +1325,25 @@ if (window = w_releasemouse && !mouse_check_button(mb_left)) window = 0
 draw_windows()
 
 // Draw update progress
-if (update == 4) {
+if (update == 4 or update == 5) {
 	window = -1
-	// show_debug_message(string(downloaded_size) + "/" + string(total_size))
 	draw_loading("Update", "Downloading update...", downloaded_size, total_size)
+	if (update == 5) {
+		if (file_get_size(update_file) == total_size) {
+			update = 1
+			show_message("Download complete! Click OK to begin installing the update.")
+			// At this point, the game is paused until the user dismisses the message
+			ExecuteShell(update_file, false, true)
+			game_end()
+		} else {
+			if (question("Failed to download update. Do you want to open the Note Block Studio website and update manually?", "Failed")) {
+				open_url(link_download)
+			}
+		window = w_greeting
+		update_download = -1
+		update = 1
+		}
+	}
 }
 
 window_set_cursor(curs)

--- a/scripts/control_http/control_http.gml
+++ b/scripts/control_http/control_http.gml
@@ -1,30 +1,5 @@
 // control_http()
-// Handles the update checking
-// update values:
-// -1: unable to check for update
-// 1: update found
-// 2: up to date
+// Handles the check for updates, then attempts to download it if one is available
 
-if (async_load[? "id"] = update_http) {
-    update_http = -1
-    if (async_load[? "http_status"] = 200) {
-        var res = async_load[? "result"];
-        if (is_string(res)) {
-			res = json_decode(res)
-			if(res[?"tag_name"] != undefined){ 
-				var newVersion = string_replace(res[?"tag_name"],"v","")
-				if (string_count(".", newVersion) = 2) {
-					if (newVersion = version) {
-					  update = 2
-					} else {
-						if (question("Version " + newVersion + " is available! Do you want to download it?", "Update available!")) open_url(link_download)
-						update = 1
-					}
-				}
-			}else
-			   update = -1
-        }else
-		   update = -1
-    } else
-        update = -1
-}
+check_updates()
+get_update()

--- a/scripts/draw_downloadprogress/draw_downloadprogress.gml
+++ b/scripts/draw_downloadprogress/draw_downloadprogress.gml
@@ -1,0 +1,25 @@
+// draw_downloadprogress(caption, desc, downloaded_size, total_size)
+var caption, desc, done, total, done_mb, total_mb, percent, x1, y1;
+caption = argument0
+desc = argument1
+done = argument2
+total = argument3
+percent = done/total
+done_mb = done/power(1024, 2)
+total_mb = total/power(1024, 2)
+x1 = floor(window_width / 2 - 150)
+y1 = floor(window_height / 2 - 50)
+draw_theme_color()
+draw_window(x1, y1, x1 + 300, y1 + 100)
+draw_set_font(fnt_mainbold)
+draw_text(x1 + 16, y1 + 16, caption)
+draw_set_font(fnt_main)
+draw_set_halign(fa_center)
+draw_text(floor(window_width / 2), y1 + 40, desc)
+draw_set_color(10512464)
+draw_rectangle(x1 + 30, y1 + 60, x1 + 30 + percent * 240, y1 + 80, 0)
+draw_theme_color()
+draw_rectangle(x1 + 30, y1 + 60, x1 + 270, y1 + 80, 1)
+if (percent > 0.5) draw_set_color(c_white)
+draw_text(floor(window_width / 2), y1 + 65, string_format(done_mb, 0, 2) + "/" + string_format(total_mb, 0, 2) + " MB (" + string(round(percent * 100)) + "%)")
+draw_set_halign(fa_left)

--- a/scripts/draw_downloadprogress/draw_downloadprogress.gml
+++ b/scripts/draw_downloadprogress/draw_downloadprogress.gml
@@ -1,5 +1,5 @@
 // draw_downloadprogress(caption, desc, downloaded_size, total_size)
-var caption, desc, done, total, done_mb, total_mb, percent, x1, y1;
+var caption, desc, done, total, done_mb, total_mb, done_text, total_text, text, percent, x1, y1;
 caption = argument0
 desc = argument1
 done = argument2
@@ -21,5 +21,13 @@ draw_rectangle(x1 + 30, y1 + 60, x1 + 30 + percent * 240, y1 + 80, 0)
 draw_theme_color()
 draw_rectangle(x1 + 30, y1 + 60, x1 + 270, y1 + 80, 1)
 if (percent > 0.5) draw_set_color(c_white)
-draw_text(floor(window_width / 2), y1 + 65, string_format(done_mb, 0, 2) + "/" + string_format(total_mb, 0, 2) + " MB (" + string(round(percent * 100)) + "%)")
+if (total <= 0) {
+	done_text = "-.--"
+	total_text = "-.--"
+} else {
+	done_text = string_format(done_mb, 0, 2)
+	total_text = string_format(total_mb, 0, 2)
+}
+text = done_text + "/" + total_text + " MB (" + string(round(percent * 100)) + "%)"
+draw_text(floor(window_width / 2), y1 + 65, text)
 draw_set_halign(fa_left)

--- a/scripts/draw_downloadprogress/draw_downloadprogress.yy
+++ b/scripts/draw_downloadprogress/draw_downloadprogress.yy
@@ -1,0 +1,8 @@
+{
+    "id": "252af0d3-fda0-4686-99ee-e50c77599791",
+    "modelName": "GMScript",
+    "mvc": "1.0",
+    "name": "draw_downloadprogress",
+    "IsCompatibility": false,
+    "IsDnD": false
+}

--- a/scripts/draw_loading/draw_loading.gml
+++ b/scripts/draw_loading/draw_loading.gml
@@ -1,12 +1,8 @@
-// draw_loading(caption, desc, percent)
-var caption, desc, done, total, done_mb, total_mb, percent, x1, y1;
+/*draw_loading(caption, desc, percent)
+var caption, desc, perc, x1, y1;
 caption = argument0
 desc = argument1
-done = argument2
-total = argument3
-percent = done/total
-done_mb = done/power(1024, 2)
-total_mb = total/power(1024, 2)
+perc = argument2
 x1 = floor(window_width / 2 - 150)
 y1 = floor(window_height / 2 - 50)
 draw_theme_color()
@@ -17,9 +13,10 @@ draw_set_font(fnt_main)
 draw_set_halign(fa_center)
 draw_text(floor(window_width / 2), y1 + 40, desc)
 draw_set_color(10512464)
-draw_rectangle(x1 + 30, y1 + 60, x1 + 30 + percent * 240, y1 + 80, 0)
+draw_rectangle(x1 + 30, y1 + 60, x1 + 30 + perc * 240, y1 + 80, 0)
 draw_theme_color()
 draw_rectangle(x1 + 30, y1 + 60, x1 + 270, y1 + 80, 1)
-if (percent > 0.5) draw_set_color(c_white)
-draw_text(floor(window_width / 2), y1 + 65, string_format(done_mb, 0, 2) + "/" + string_format(total_mb, 0, 2) + " MB (" + string(round(percent * 100)) + "%)")
+if (perc > 0.5) draw_set_color(c_white)
+draw_text(floor(window_width / 2), y1 + 65, string(floor(perc * 100)) + "% done")
 draw_set_halign(fa_left)
+screen_refresh()

--- a/scripts/draw_loading/draw_loading.gml
+++ b/scripts/draw_loading/draw_loading.gml
@@ -1,8 +1,12 @@
-/*draw_loading(caption, desc, percent)
-var caption, desc, perc, x1, y1;
+// draw_loading(caption, desc, percent)
+var caption, desc, done, total, done_mb, total_mb, percent, x1, y1;
 caption = argument0
 desc = argument1
-perc = argument2
+done = argument2
+total = argument3
+percent = done/total
+done_mb = done/power(1024, 2)
+total_mb = total/power(1024, 2)
 x1 = floor(window_width / 2 - 150)
 y1 = floor(window_height / 2 - 50)
 draw_theme_color()
@@ -13,10 +17,9 @@ draw_set_font(fnt_main)
 draw_set_halign(fa_center)
 draw_text(floor(window_width / 2), y1 + 40, desc)
 draw_set_color(10512464)
-draw_rectangle(x1 + 30, y1 + 60, x1 + 30 + perc * 240, y1 + 80, 0)
+draw_rectangle(x1 + 30, y1 + 60, x1 + 30 + percent * 240, y1 + 80, 0)
 draw_theme_color()
 draw_rectangle(x1 + 30, y1 + 60, x1 + 270, y1 + 80, 1)
-if (perc > 0.5) draw_set_color(c_white)
-draw_text(floor(window_width / 2), y1 + 65, string(floor(perc * 100)) + "% done")
+if (percent > 0.5) draw_set_color(c_white)
+draw_text(floor(window_width / 2), y1 + 65, string_format(done_mb, 0, 2) + "/" + string_format(total_mb, 0, 2) + " MB (" + string(round(percent * 100)) + "%)")
 draw_set_halign(fa_left)
-screen_refresh()

--- a/scripts/file_get_size/file_get_size.gml
+++ b/scripts/file_get_size/file_get_size.gml
@@ -1,0 +1,12 @@
+// file_get_size(path)
+// Returns the size of a file, in bytes.
+
+var path, file, size
+path = argument0
+if (file_exists(path)) {
+	file = file_bin_open(path, 0)
+	size = file_bin_size(file)
+	file_bin_close(file)
+	return size
+}
+return 0

--- a/scripts/file_get_size/file_get_size.yy
+++ b/scripts/file_get_size/file_get_size.yy
@@ -1,0 +1,8 @@
+{
+    "id": "f136e3ca-963a-4648-ae87-60c3ee8476a9",
+    "modelName": "GMScript",
+    "mvc": "1.0",
+    "name": "file_get_size",
+    "IsCompatibility": false,
+    "IsDnD": false
+}

--- a/scripts/get_update/get_update.gml
+++ b/scripts/get_update/get_update.gml
@@ -15,7 +15,7 @@ if (async_load[? "id"] == update_download) {
 		if (file_get_size(update_file) == total_size) {
 			show_message("Download complete! Click OK to begin installing the update.")
 			// At this point, the game is paused until the user dismisses the message
-			ExecuteShell(update_file, false, true)
+			ExecuteShell("\"" + update_file + "\"", false, true)
 			game_end()
 		} else {
 			if (question("Failed to download update. Do you want to open the Note Block Studio website and update manually?", "Failed")) {

--- a/scripts/get_update/get_update.gml
+++ b/scripts/get_update/get_update.gml
@@ -1,0 +1,28 @@
+// get_update()
+// Attempts to download a newer version if one is available
+// status:
+// 1 - receiving packets (download in progress)
+// 0 - success (download complete)
+
+if (async_load[? "id"] == update_download) {
+	var http_status = async_load[? "http_status"]
+	var status = async_load[? "status"]
+	show_debug_message(string(http_status))
+    if (status == 1) {
+		downloaded_size = async_load[? "sizeDownloaded"]
+		total_size = async_load[? "contentLength"]
+	} else if (status == 0) {
+		show_debug_message(string(http_status))
+		show_message("Download complete! Click OK to begin installing the update.")
+		// At this point, the game is paused until the user dismisses the message
+		ExecuteShell(update_file, false, true)
+		game_end()
+	} else {
+		if (question("Failed to download update. Do you want to open the Note Block Studio website and update manually?", "Failed")) {
+			open_url(link_download)
+		}
+		window = w_greeting
+		update_download = -1
+		update = 1
+	}
+}

--- a/scripts/get_update/get_update.gml
+++ b/scripts/get_update/get_update.gml
@@ -5,7 +5,6 @@
 // 0 - success (download complete)
 
 if (async_load[? "id"] == update_download) {
-	var http_status = async_load[? "http_status"]
 	var status = async_load[? "status"]
     if (status == 1) {
 		downloaded_size = async_load[? "sizeDownloaded"]
@@ -13,5 +12,18 @@ if (async_load[? "id"] == update_download) {
 	} else if (status == 0) {
 		// Download was interrupted, may have been successful or not (if connection was interrupted)
 		update = 5
+		if (file_get_size(update_file) == total_size) {
+			show_message("Download complete! Click OK to begin installing the update.")
+			// At this point, the game is paused until the user dismisses the message
+			ExecuteShell(update_file, false, true)
+			game_end()
+		} else {
+			if (question("Failed to download update. Do you want to open the Note Block Studio website and update manually?", "Failed")) {
+				open_url(link_download)
+			}
+		window = w_greeting
+		update_download = -1
+		update = 1
+		}
 	}
 }

--- a/scripts/get_update/get_update.gml
+++ b/scripts/get_update/get_update.gml
@@ -7,22 +7,11 @@
 if (async_load[? "id"] == update_download) {
 	var http_status = async_load[? "http_status"]
 	var status = async_load[? "status"]
-	show_debug_message(string(http_status))
     if (status == 1) {
 		downloaded_size = async_load[? "sizeDownloaded"]
 		total_size = async_load[? "contentLength"]
 	} else if (status == 0) {
-		show_debug_message(string(http_status))
-		show_message("Download complete! Click OK to begin installing the update.")
-		// At this point, the game is paused until the user dismisses the message
-		ExecuteShell(update_file, false, true)
-		game_end()
-	} else {
-		if (question("Failed to download update. Do you want to open the Note Block Studio website and update manually?", "Failed")) {
-			open_url(link_download)
-		}
-		window = w_greeting
-		update_download = -1
-		update = 1
+		// Download was interrupted, may have been successful or not (if connection was interrupted)
+		update = 5
 	}
 }

--- a/scripts/get_update/get_update.yy
+++ b/scripts/get_update/get_update.yy
@@ -1,0 +1,8 @@
+{
+    "id": "e74f03fa-1407-4d25-93ab-0dccb3eb91ca",
+    "modelName": "GMScript",
+    "mvc": "1.0",
+    "name": "get_update",
+    "IsCompatibility": false,
+    "IsDnD": false
+}

--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -14,7 +14,7 @@
 #macro pattern_directory	data_directory + "Patterns\\"
 #macro log_file				file_directory + "log.txt"
 #macro temp_file			file_directory + "tmp.file"
-#macro update_file			file_directory + "update.exe"
+#macro update_file			file_directory + "Minecraft Note Block Studio Setup.exe"
 #macro settings_file		file_directory + "settings.ini"
 #macro backup_file			file_directory + "backup.nbs"
 

--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -1,6 +1,6 @@
 #macro gm_runtime_version "2.2.3.344"
 #macro version_date "2019.12.31"
-#macro version "3.6.0"
+#macro version "3.7.0"
 #macro nbs_version 4
 #macro pat_version 1
 
@@ -14,7 +14,7 @@
 #macro pattern_directory	data_directory + "Patterns\\"
 #macro log_file				file_directory + "log.txt"
 #macro temp_file			file_directory + "tmp.file"
-#macro update_file			file_directory + "Minecraft Note Block Studio Setup.exe"
+#macro update_file			file_directory + "Minecraft Note Block Studio Installer.exe"
 #macro settings_file		file_directory + "settings.ini"
 #macro backup_file			file_directory + "backup.nbs"
 

--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -1,10 +1,10 @@
 #macro gm_runtime_version "2.2.3.344"
 #macro version_date "2019.12.31"
-#macro version "3.7.0"
+#macro version "3.6.0"
 #macro nbs_version 4
 #macro pat_version 1
 
-#macro link_download "https://github.com/HielkeMinecraft/OpenNoteBlockStudio/releases/latest"
+#macro link_download "https://hielkeminecraft.github.io/OpenNoteBlockStudio/"
 #macro link_topic "https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-tools/2945101-open-minecraft-note-block-studio"
 
 #macro file_directory		game_save_id
@@ -14,6 +14,7 @@
 #macro pattern_directory	data_directory + "Patterns\\"
 #macro log_file				file_directory + "log.txt"
 #macro temp_file			file_directory + "tmp.file"
+#macro update_file			file_directory + "update.exe"
 #macro settings_file		file_directory + "settings.ini"
 #macro backup_file			file_directory + "backup.nbs"
 

--- a/views/56f20c67-9fcc-4085-9cad-4785628f8831.yy
+++ b/views/56f20c67-9fcc-4085-9cad-4785628f8831.yy
@@ -15,7 +15,9 @@
         "caf03170-c1fc-42ce-abd4-cc04c23cc07e",
         "0ce5a906-0342-42fb-89f3-04f3609f5689",
         "3ef34f15-11b7-471c-aa91-4f191100f959",
-        "0097ab11-b126-461a-8194-e3aaf09a6ddd"
+        "0097ab11-b126-461a-8194-e3aaf09a6ddd",
+        "3c1514e1-5885-49b4-86ef-115f1fdec3ea",
+        "e74f03fa-1407-4d25-93ab-0dccb3eb91ca"
     ],
     "filterType": "GMScript",
     "folderName": "Controller",

--- a/views/851a6098-0a35-48ef-8f86-8d6cd677f3fd.yy
+++ b/views/851a6098-0a35-48ef-8f86-8d6cd677f3fd.yy
@@ -21,6 +21,7 @@
         "28131748-b621-459e-952c-fcd16de0bd8b",
         "36bf530d-9afd-4915-8e0f-6d9162ea03b2",
         "f6cfba59-defd-47c1-b2fa-8fa627a1c1a4",
+        "252af0d3-fda0-4686-99ee-e50c77599791",
         "ffdb58ba-3567-4019-acf7-c6e674131bbb",
         "bb77e968-5a4f-4c9d-954b-7ddca77d2c0a",
         "a38ae6de-e436-4b50-af0b-964bf5f26cd9",

--- a/views/a89d59b8-0ac7-4c34-a3aa-a1c4e95fa1e3.yy
+++ b/views/a89d59b8-0ac7-4c34-a3aa-a1c4e95fa1e3.yy
@@ -16,7 +16,8 @@
         "395e2149-7095-4b85-9a90-9b808723ddb7",
         "af9a3525-3682-420e-b2a0-d952cc347296",
         "a0fe9bd7-a654-4de6-abd8-41b5be7e41a8",
-        "7dfa1c5c-2dd7-4604-a776-ff2a1c2d26b0"
+        "7dfa1c5c-2dd7-4604-a776-ff2a1c2d26b0",
+        "f136e3ca-963a-4648-ae87-60c3ee8476a9"
     ],
     "filterType": "GMScript",
     "folderName": "File",


### PR DESCRIPTION
When a new update is available, instead of opening the website, the program will attempt to download it automatically. The installer for the new version will be saved as `Minecraft Note Block Studio Setup.exe` on the program's root directory, and when successfully downloaded, it will be opened automatically, followed by the closure of the program. In case the download fails, only then the user will be prompted if they want to go to the website and update manually.

This change should not only make it easier to distribute updates, but more convenient for the user to get them -- especially if new updates are released on a frequent basis. It allows the user to access new versions without even opening a browser.