### PR TITLE
3.8.2

### DIFF
--- a/datafiles/Data/changelog.txt
+++ b/datafiles/Data/changelog.txt
@@ -1,3 +1,12 @@
+Changes in v3.8.2 (2021.01.04):
+* Added a warning about version compatibility when exporting a schematic.
+* Fixed a crash when trying to export a schematic.
+* Fixed settings being saved too often, causing high disk and CPU usage.
+* Fixed wrong note block counts in Compatibility and Song stats.
+* Fixed red outline on out-of-range blocks being too large.
+* Fixed a glitch in the Save options window when using the Aqua theme.
+* Fixed a blurry button in Instrument settings.
+
 Changes in v3.8.1 (2020.12.31):
 * Increased max number of custom instruments from 18 to 240.
 * It's now possible to reorder custom instruments on the instrument settings.
@@ -238,7 +247,6 @@ Changes in v3.4.0 (2019.05.11):
 Changes in v3.3.8 (2019.03.21):
 * Fixed a glitch with layer names.
 * Fixed a glitch with compatibility indicator.
-
 
 Changes in v3.3.7 (2019.03.13):
 * Changed fonts.

--- a/scripts/add_block_manual/add_block_manual.gml
+++ b/scripts/add_block_manual/add_block_manual.gml
@@ -35,9 +35,11 @@ function add_block_manual(argument0, argument1, argument2, argument3, argument4,
 	if ((key < 33  || key > 57) && warning_octaves = 0) {
 	    message("NOTE: Since this block is outside the 2 octave limit, you won't be able to import it into Minecraft without a resource pack.\n\nThis warning will never be shown again.", "Warning")
 	    warning_octaves = 1
+		save_settings()
 	} else if (ins.user && warning_instrument = 0) {
 	    message("NOTE: Since this block has a custom instrument, you won't be able to import it into Minecraft without mods or resource packs.\n\nThis warning will never be shown again.", "Warning")
 	    warning_instrument = 1
+		save_settings()
 	}
 
 	// Add block

--- a/scripts/blocks_set_instruments/blocks_set_instruments.gml
+++ b/scripts/blocks_set_instruments/blocks_set_instruments.gml
@@ -8,10 +8,9 @@ function blocks_set_instruments() {
 	    if (colamount[a] > 0) {
 	        for (b = 0; b <= collast[a]; b += 1) {
 	            if (song_exists[a, b]) {
-					show_debug_message(instrument_list[| song_ins[a, b]])
 	                song_ins[a, b] = instrument_list[| song_ins[a, b]]
-	                //song_ins[a, b].num_blocks++
-	                //if (song_ins[a, b].user) block_custom++
+	                song_ins[a, b].num_blocks++
+	                if (song_ins[a, b].user) block_custom++
 	            }
 	        }
 	    }

--- a/scripts/calculate_size/calculate_size.gml
+++ b/scripts/calculate_size/calculate_size.gml
@@ -1,5 +1,10 @@
 function calculate_size() {
 	var a, b, c;
+	if (warning_schematic == 0) {
+		message("The exported schematic is currently only compatible with Minecraft: Java Edition 1.12 and below. To import it in 1.13 and above, first create a world in 1.12, import the schematic, then open the world in 1.13 or above. Newer versions may be supported in the future.\n\nThis warning will never be shown again.", "Warning")
+		warning_schematic = 1
+		save_settings()
+	}
 	if (block_outside > 0) {
 	    if (!question("Some note blocks are outside of Minecraft's 2 octave limit. Do you want to export a Schematic anyway, ignoring the affected blocks?", "Minecraft Compatibility")) return 0
 	}

--- a/scripts/calculate_size/calculate_size.gml
+++ b/scripts/calculate_size/calculate_size.gml
@@ -75,7 +75,7 @@ function calculate_size() {
 	    for (b = 0; b < 2; b += 1) {
 	        if (a <= scp_exp_enda[b]) {
 	            sch_exp_repeaters[b, 2] += 1
-	            if (sch_colamount[a] > 0) {
+	            if (sch_colamount[b, a] > 0) {
 	                sch_exp_repeaters[b, 0] += 1
 	                cnt[b, 0] = 0
 	                sch_exp_repeaters[b, 1] += 1

--- a/scripts/control_draw/control_draw.gml
+++ b/scripts/control_draw/control_draw.gml
@@ -49,9 +49,11 @@ function control_draw() {
 	    if (keyboard_check_pressed(vk_enter) || keyboard_check_pressed(vk_space) || keyboard_check_pressed(vk_escape)) {
 	        piano_key[key_edit] = 0
 	        key_edit = -1
+			save_settings()
 	    } else if (keyboard_check_pressed(vk_anykey)) {
 	        piano_key[key_edit] = keyboard_lastkey
 	        key_edit = -1
+			save_settings()
 	    }
 	}
 

--- a/scripts/draw_block/draw_block.gml
+++ b/scripts/draw_block/draw_block.gml
@@ -61,7 +61,7 @@ function draw_block(argument0, argument1, argument2, argument3, argument4, argum
 	if (show_incompatible && (ins.user || key < 33 || key > 57)) {
 	    draw_set_color(c_red)
 	    draw_set_alpha(1)
-	    draw_rectangle(xx, yy, xx + 32, yy + 32, 1)
+	    draw_rectangle(xx + 1, yy + 1, xx + 31, yy + 31, 1)
 	}
 	draw_set_color(c_white)
 	if (salpha > 0) {

--- a/scripts/draw_window_instruments/draw_window_instruments.gml
+++ b/scripts/draw_window_instruments/draw_window_instruments.gml
@@ -78,6 +78,7 @@ function draw_window_instruments() {
 			show_message("This song contains more than 18 instruments and cannot be saved in version " + string(save_version) + ". The save version will be changed to " + string(nbs_version) + ".")
 			save_version = nbs_version
 		}
+		save_settings()
 	}
 	if (mouse_check_button_pressed(mb_left)) {
 	    insedit = -1
@@ -170,7 +171,6 @@ function draw_window_instruments() {
 	draw_line(x1 + 13 + 194 + 160 + 80, y1 + 87, x1 + 13 + 194 + 160 + 80, y1 + 86 + 20 * a)
 	draw_scrollbar(insscrollbar, x1 + 14 + 194 + 160 + 80 + 70, y1 + 88, 21, 9, ds_list_size(instrument_list) - 2, 0, 1)
 	window_set_cursor(curs)
-	save_settings()
 
 
 }

--- a/scripts/draw_window_instruments/draw_window_instruments.gml
+++ b/scripts/draw_window_instruments/draw_window_instruments.gml
@@ -42,7 +42,7 @@ function draw_window_instruments() {
 			sounds++
 		}
 	}
-	if (draw_button2(x1 + 12, y1 + 318, 85, "Export sounds", (user_instruments == 0 || sounds == 0))) pack_instruments()
+	if (draw_button2(x1 + 12, y1 + 318, 86, "Export sounds", (user_instruments == 0 || sounds == 0))) pack_instruments()
 	c = 0
 	if (draw_button2(x1 + 110, y1 + 318, 80, "Add", user_instruments >= 240) && wmenu = 0) {
 	    changed = true

--- a/scripts/draw_window_preferences/draw_window_preferences.gml
+++ b/scripts/draw_window_preferences/draw_window_preferences.gml
@@ -188,10 +188,11 @@ function draw_window_preferences() {
 		if (draw_radiobox(x1 + 233 + 32, y1 + 224 + 16, !use_bpm, "Ticks per second (t/s)", "Display song tempos in ticks per second.")) use_bpm = 0
 		if (draw_radiobox(x1 + 233 + 32, y1 + 244 + 16, use_bpm, "Beats per minute (BPM)", "Display song tempos in beats per minute.")) use_bpm = 1
 	}
-	if (draw_button2(x1 + 420, y1 + 478, 72, "OK")) window = 0
-	window_set_cursor(curs)
-	save_settings()
-
+	if (draw_button2(x1 + 420, y1 + 478, 72, "OK")) {
+		window = 0
+		window_set_cursor(curs)
+		save_settings()
+	}
 
 
 }

--- a/scripts/draw_window_save_options/draw_window_save_options.gml
+++ b/scripts/draw_window_save_options/draw_window_save_options.gml
@@ -11,9 +11,9 @@ function draw_window_save_options() {
 	draw_set_font(fnt_main)
 	if (theme = 0) {
 	    draw_set_color(c_white)
-	    draw_rectangle(x1 + 6, y1 + 26, x1 + 134, y1 + 117, 0)
+	    draw_rectangle(x1 + 6, y1 + 26, x1 + 134, y1 + 132, 0)
 	    draw_set_color(make_color_rgb(137, 140, 149))
-	    draw_rectangle(x1 + 6, y1 + 26, x1 + 134, y1 + 117, 1)
+	    draw_rectangle(x1 + 6, y1 + 26, x1 + 134, y1 + 132, 1)
 	}
 	draw_theme_color()
 	

--- a/scripts/draw_window_update/draw_window_update.gml
+++ b/scripts/draw_window_update/draw_window_update.gml
@@ -38,6 +38,7 @@ function draw_window_update() {
 	if (draw_button2(x1 + 220, y1 + 340, 72, "OK")) {
 	    if (window = w_update) {
 	        window = w_greeting
+			save_settings() // Save new version number
 	    } else {
 	        window = 0
 	    }

--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -1,7 +1,7 @@
 function macros() {
 #macro gm_runtime_version "2.2.3.344"
-#macro version_date "2020.12.31"
-#macro version "3.8.1"
+#macro version_date "2021.01.04"
+#macro version "3.8.2"
 #macro nbs_version 5
 #macro pat_version 1
 


### PR DESCRIPTION
* Added a warning about version compatibility when exporting a schematic.
* Fixed a crash when trying to export a schematic.
* Fixed settings being saved too often, causing high disk and CPU usage.
* Fixed wrong note block counts in Compatibility and Song stats.
* Fixed red outline on out-of-range blocks being too large.
* Fixed a glitch in the Save options window when using the Aqua theme.
* Fixed a blurry button in Instrument settings.